### PR TITLE
Ignore NXPNFCC_FW sub-directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+NXPNFCC_FW/*


### PR DESCRIPTION
NXPNFCC_FW sub-directory is appending from another git repository. This commit is to not have unstaged changes.