### PR TITLE
Move firmware to /vendor/lib on SDK >= 28

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -25,7 +25,11 @@ LOCAL_MODULE_TAGS := optional
 LOCAL_MODULE_STEM := libpn547_fw
 LOCAL_MODULE_SUFFIX := .so
 LOCAL_MODULE_CLASS := ETC
+ifeq ($(call math_gt_or_eq, $(PLATFORM_SDK_VERSION), 28), true)
+LOCAL_MODULE_PATH := $(TARGET_OUT_VENDOR)/lib
+else
 LOCAL_MODULE_PATH := $(TARGET_OUT_VENDOR)/firmware
+endif
 include $(BUILD_PREBUILT)
 else
 include $(CLEAR_VARS)
@@ -36,7 +40,11 @@ LOCAL_MODULE_TAGS := optional
 LOCAL_MODULE_STEM := libpn547_fw
 LOCAL_MODULE_SUFFIX := .so
 LOCAL_MODULE_CLASS := ETC
+ifeq ($(call math_gt_or_eq, $(PLATFORM_SDK_VERSION), 28), true)
+LOCAL_MODULE_PATH := $(TARGET_OUT_VENDOR)/lib
+else
 LOCAL_MODULE_PATH := $(TARGET_OUT_VENDOR)/firmware
+endif
 include $(BUILD_PREBUILT)
 endif
 endif
@@ -51,7 +59,11 @@ LOCAL_MODULE_TAGS := optional
 LOCAL_MODULE_STEM := libpn548_fw
 LOCAL_MODULE_SUFFIX := .so
 LOCAL_MODULE_CLASS := ETC
+ifeq ($(call math_gt_or_eq, $(PLATFORM_SDK_VERSION), 28), true)
+LOCAL_MODULE_PATH := $(TARGET_OUT_VENDOR)/lib
+else
 LOCAL_MODULE_PATH := $(TARGET_OUT_VENDOR)/firmware
+endif
 include $(BUILD_PREBUILT)
 else
 include $(CLEAR_VARS)
@@ -62,7 +74,11 @@ LOCAL_MODULE_TAGS := optional
 LOCAL_MODULE_STEM := libpn548_fw
 LOCAL_MODULE_SUFFIX := .so
 LOCAL_MODULE_CLASS := ETC
+ifeq ($(call math_gt_or_eq, $(PLATFORM_SDK_VERSION), 28), true)
+LOCAL_MODULE_PATH := $(TARGET_OUT_VENDOR)/lib
+else
 LOCAL_MODULE_PATH := $(TARGET_OUT_VENDOR)/firmware
+endif
 include $(BUILD_PREBUILT)
 endif
 endif
@@ -77,7 +93,11 @@ LOCAL_MODULE_TAGS := optional
 LOCAL_MODULE_STEM := libpn551_fw
 LOCAL_MODULE_SUFFIX := .so
 LOCAL_MODULE_CLASS := ETC
+ifeq ($(call math_gt_or_eq, $(PLATFORM_SDK_VERSION), 28), true)
+LOCAL_MODULE_PATH := $(TARGET_OUT_VENDOR)/lib
+else
 LOCAL_MODULE_PATH := $(TARGET_OUT_VENDOR)/firmware
+endif
 include $(BUILD_PREBUILT)
 else
 include $(CLEAR_VARS)
@@ -88,7 +108,11 @@ LOCAL_MODULE_TAGS := optional
 LOCAL_MODULE_STEM := libpn551_fw
 LOCAL_MODULE_SUFFIX := .so
 LOCAL_MODULE_CLASS := ETC
+ifeq ($(call math_gt_or_eq, $(PLATFORM_SDK_VERSION), 28), true)
+LOCAL_MODULE_PATH := $(TARGET_OUT_VENDOR)/lib
+else
 LOCAL_MODULE_PATH := $(TARGET_OUT_VENDOR)/firmware
+endif
 include $(BUILD_PREBUILT)
 endif
 endif
@@ -103,7 +127,11 @@ LOCAL_MODULE_TAGS := optional
 LOCAL_MODULE_STEM := libpn553_fw
 LOCAL_MODULE_SUFFIX := .so
 LOCAL_MODULE_CLASS := ETC
+ifeq ($(call math_gt_or_eq, $(PLATFORM_SDK_VERSION), 28), true)
+LOCAL_MODULE_PATH := $(TARGET_OUT_VENDOR)/lib
+else
 LOCAL_MODULE_PATH := $(TARGET_OUT_VENDOR)/firmware
+endif
 include $(BUILD_PREBUILT)
 else
 include $(CLEAR_VARS)
@@ -114,7 +142,11 @@ LOCAL_MODULE_TAGS := optional
 LOCAL_MODULE_STEM := libpn553_fw
 LOCAL_MODULE_SUFFIX := .so
 LOCAL_MODULE_CLASS := ETC
+ifeq ($(call math_gt_or_eq, $(PLATFORM_SDK_VERSION), 28), true)
+LOCAL_MODULE_PATH := $(TARGET_OUT_VENDOR)/lib
+else
 LOCAL_MODULE_PATH := $(TARGET_OUT_VENDOR)/firmware
+endif
 include $(BUILD_PREBUILT)
 endif
 endif


### PR DESCRIPTION
* android.hardware.nfc@1.1-service on P is loading firmware
  files from /vendor/lib instead of /vendor/firmware.