### PR TITLE
[VENDOR-NXP] Android.mk: Add PN557 firmware

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -150,3 +150,38 @@ endif
 include $(BUILD_PREBUILT)
 endif
 endif
+
+ifeq ($(NXP_CHIP_FW_TYPE), PN557)
+ifneq ($(TARGET_ARCH), arm64)
+include $(CLEAR_VARS)
+LOCAL_MODULE := libpn553_fw
+LOCAL_MODULE_OWNER := Open Source
+LOCAL_SRC_FILES := NXPNFCC_FW/pn557/32-bit/libpn557_fw.so
+LOCAL_MODULE_TAGS := optional
+LOCAL_MODULE_STEM := libpn553_fw
+LOCAL_MODULE_SUFFIX := .so
+LOCAL_MODULE_CLASS := ETC
+ifeq ($(call math_gt_or_eq, $(PLATFORM_SDK_VERSION), 28), true)
+LOCAL_MODULE_PATH := $(TARGET_OUT_VENDOR)/lib
+else
+LOCAL_MODULE_PATH := $(TARGET_OUT_VENDOR)/firmware
+endif
+include $(BUILD_PREBUILT)
+else
+include $(CLEAR_VARS)
+LOCAL_MODULE := libpn553_fw
+LOCAL_MODULE_OWNER := Open Source
+LOCAL_SRC_FILES := NXPNFCC_FW/pn557/64-bit/libpn557_fw.so
+LOCAL_MODULE_TAGS := optional
+LOCAL_MODULE_STEM := libpn553_fw
+LOCAL_MODULE_SUFFIX := .so
+LOCAL_MODULE_CLASS := ETC
+ifeq ($(call math_gt_or_eq, $(PLATFORM_SDK_VERSION), 28), true)
+LOCAL_MODULE_PATH := $(TARGET_OUT_VENDOR)/lib
+else
+LOCAL_MODULE_PATH := $(TARGET_OUT_VENDOR)/firmware
+endif
+include $(BUILD_PREBUILT)
+endif
+endif
+


### PR DESCRIPTION
The PN557 firmware is used in the SoMC SM8150 Kumano platform
but there's a quirk: the NXP NFC HAL is requesting the firmware
as "libpn553_fw.so" instead of "libpn557_fw.so".

For this reason, declare the PN557 FW as libpn553_fw: this
anyway has a barrier for NXP_CHIP_FW_TYPE, so we cannot get
any conflict with the real pn553 anyway.

P.S.: The other way would be to declare it as LOCAL_MODULE
libpn557_fw, but then we would have to add an ifeq for the
NXP_CHIP_FW_TYPE also in the nxp-vendor.mk, where we select
the firmwares to add to the build.

Let's keep it simple!